### PR TITLE
Add android_deps attr for android resources

### DIFF
--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -50,6 +50,11 @@ def _kotlin_compile_impl(ctx):
             for file in fileset:
                 jars += [file]
 
+    # Populate from android dependencies
+    for dep in ctx.attr.android_deps:
+        if dep.android.defines_resources:
+            jars.append(dep.android.resource_jar.class_jar)
+
     if jars:
         # De-duplicate
         jarsetlist = list(set(jars))
@@ -118,6 +123,11 @@ _kotlin_compile_attrs = {
     # Dependent java rules.
     "java_deps": attr.label_list(
         providers = ["java"],
+    ),
+
+    # Dependent java rules.
+    "android_deps": attr.label_list(
+        providers = ["android"],
     ),
 
     # Not really implemented yet.


### PR DESCRIPTION
This adds an `android_deps` attr to the Kotlin rules that allows them to
depend on the resources exposed from `android_library`.

There's probably more to do here in the cases where the `android_library` has more than just resources, but this is a start. If you'd prefer a more complete implementation, no worries.