### PR TITLE
Use non-ABI jars for kotlin compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ os:
 env:
   #- V=HEAD
   - V=0.7.0
-  - V=0.6.1
-  - V=0.5.4
-  - V=0.5.0
-  - V=0.4.5
 
 before_install:
   - OS=linux

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Build [Kotlin][kotlin] source with with [Bazel][bazel].
 | [`kotlin_android_library`](#kotlin_android_library) | Build an android library from kotlin source |
 | [`kotlin_test`](#kotlin_test) | Run a kotlin test |
 
-> Note: **Bazel 0.4.5 or higher is required**.
+> Note: **Bazel 0.7.0 or higher is required for rules_kotlin 0.5.0**.
 
 ## Workspace rules
 
@@ -29,7 +29,7 @@ Add the following to your `WORKSPACE` file:
 git_repository(
     name = "org_pubref_rules_kotlin",
     remote = "https://github.com/pubref/rules_kotlin.git",
-    tag = "v0.4.1", # update as needed
+    tag = "v0.5.0", # update as needed
 )
 
 load("@org_pubref_rules_kotlin//kotlin:rules.bzl", "kotlin_repositories")

--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -65,11 +65,7 @@ def _kotlin_compile_impl(ctx):
 
     if jars:
         # De-duplicate
-        jarsetlist = depset(jars).to_list()
-        jarlist = []
-        for f in jarsetlist:
-            if not f.basename.startswith('kotlin-'):
-                jarlist.append(f)
+        jarlist = depset(jars).to_list()
         args += ["-cp", ":".join([f.path for f in jarlist])]
         inputs += jarlist
         if ctx.attr.verbose:

--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -44,7 +44,7 @@ def _kotlin_compile_impl(ctx):
             info = dep[java_common.provider]
             # Don't use the ABI jars!
             jars += info.full_compile_jars
-
+            
     # Populate from (transitive) kotlin dependencies
     for dep in ctx.attr.deps:
         jars += [file for file in dep.kt.transitive_jars]
@@ -68,7 +68,7 @@ def _kotlin_compile_impl(ctx):
         jarsetlist = depset(jars).to_list()
         jarlist = []
         for f in jarsetlist:
-            if f.path.find('kotlin') < 0:
+            if not f.basename.startswith('kotlin-'):
                 jarlist.append(f)
         args += ["-cp", ":".join([f.path for f in jarlist])]
         inputs += jarlist

--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -32,17 +32,18 @@ def _kotlin_compile_impl(ctx):
     # preloader
     inputs += ctx.files._kotlin_home
 
+    args += ctx.attr.args
+    
     # Make classpath if needed.  Include those from this and dependent rules.
-    jars = []
+    jars = depset()
 
-    # Populate from (transitive) java dependencies
+    # Populate from (transitive) java dependencies.  
     for dep in ctx.attr.java_deps:
         # Add-in all source and generated jar files
-        for file in dep.files:
-            jars.append(file)
-        # Add-in transitive dependencies
-        for file in dep.java.transitive_deps:
-            jars.append(file)
+        if java_common.provider in dep:
+            info = dep[java_common.provider]
+            # Don't use the ABI jars!
+            jars += info.full_compile_jars
 
     # Populate from (transitive) kotlin dependencies
     for dep in ctx.attr.deps:
@@ -53,11 +54,9 @@ def _kotlin_compile_impl(ctx):
         # The fileset object is either a ConfiguredTarget OR a depset.
         files = getattr(fileset, 'files', None)
         if files:
-            for file in files:
-                jars += [file]
+            jars = jars.union(files)
         else:
-            for file in fileset:
-                jars += [file]
+            jars = jars.union(fileset)
 
     # Populate from android dependencies
     for dep in ctx.attr.android_deps:
@@ -67,14 +66,24 @@ def _kotlin_compile_impl(ctx):
     if jars:
         # De-duplicate
         jarsetlist = depset(jars).to_list()
-        args += ["-cp", ":".join([file.path for file in jarsetlist])]
-        inputs += jarsetlist
-
+        jarlist = []
+        for f in jarsetlist:
+            if f.path.find('kotlin') < 0:
+                jarlist.append(f)
+        args += ["-cp", ":".join([f.path for f in jarlist])]
+        inputs += jarlist
+        if ctx.attr.verbose:
+            print("kotlin compile classpath: \n" + "\n".join([file.path for file in jarlist]))
+            
     # Add in filepaths
     for file in ctx.files.srcs:
         inputs += [file]
         args += [file.path]
 
+
+    if ctx.attr.verbose > 1:
+        print("kotlin compile arguments: \n%s" % "\n".join(args))
+        
     # Run the compiler
     ctx.action(
         mnemonic = "KotlinCompile",
@@ -92,7 +101,7 @@ def _kotlin_compile_impl(ctx):
         kt = struct(
             srcs = ctx.attr.srcs,
             jar = kt_jar,
-            transitive_jars = [kt_jar] + jars,
+            transitive_jars = [kt_jar] + jars.to_list(),
         ),
     )
 
@@ -121,6 +130,11 @@ _kotlin_compile_attrs = {
         providers = ["java"],
     ),
 
+    # Add debugging info for the rule
+    "verbose": attr.int(
+        default = 0,
+    ),
+    
     # Dependent android rules.
     "android_deps": attr.label_list(
         providers = ["android"],
@@ -140,6 +154,9 @@ _kotlin_compile_attrs = {
     # Advanced options
     "x_opts": attr.string_list(),
 
+    # Other args
+    "args": attr.string_list(),
+    
     # Plugin options
     "plugin_opts": attr.string_dict(),
 
@@ -281,6 +298,8 @@ def kotlin_binary(name,
                   x_opts = [],
                   plugin_opts = {},
                   java_deps = [],
+                  compile_args = [],
+                  verbose = None,
                   visibility = None,
                   **kwargs):
 
@@ -291,16 +310,27 @@ def kotlin_binary(name,
         srcs = srcs,
         deps = deps,
         x_opts = x_opts,
+        args = compile_args,
         plugin_opts = plugin_opts,
         visibility = visibility,
+        verbose = verbose,
     )
 
+    runtime_deps = [name + "_kt.jar"] + java_deps + [
+        dep + "_kt"
+        for dep in deps
+    ] + ["@com_github_jetbrains_kotlin//:runtime"]
+    
+    if len(jars):
+        native.java_import(
+            name = name + "_jars",
+            jars = jars,
+        )
+        runtime_deps += [name + "_jars"]
+    
     native.java_binary(
         name = name,
-        runtime_deps = [name + "_kt.jar"] + java_deps + [
-            dep + "_kt"
-            for dep in deps
-        ] + ["@com_github_jetbrains_kotlin//:runtime"],
+        runtime_deps = runtime_deps,
         visibility = visibility,
         **kwargs
     )

--- a/tests/tornadofx/App.kt
+++ b/tests/tornadofx/App.kt
@@ -1,0 +1,12 @@
+import tornadofx.App
+import tornadofx.View
+import tornadofx.launch
+import tornadofx.vbox
+
+class MyView: View() {
+        override val root = vbox()
+}
+
+class MyApp: App(MyView::class)
+
+fun main(args: Array<String>) = launch<MyApp>(args)

--- a/tests/tornadofx/BUILD
+++ b/tests/tornadofx/BUILD
@@ -1,0 +1,14 @@
+load("@org_pubref_rules_kotlin//kotlin:rules.bzl", "kotlin_binary")
+
+kotlin_binary(
+    name = "main",
+    main_class = "AppKt",
+    srcs = ["App.kt"],
+    verbose = 2,
+    compile_args = [
+        "-jvm-target", "1.8",
+    ],
+    java_deps = [
+        "@tornadofx//:compile", 
+    ],
+)

--- a/tests/tornadofx/WORKSPACE
+++ b/tests/tornadofx/WORKSPACE
@@ -1,0 +1,42 @@
+local_repository(
+    name = 'org_pubref_rules_kotlin',
+    path = '../..',
+)
+
+load('@org_pubref_rules_kotlin//kotlin:rules.bzl', 'kotlin_repositories')
+
+kotlin_repositories()
+
+git_repository(
+    name = 'org_pubref_rules_maven',
+    remote = 'https://github.com/pubref/rules_maven',
+    commit = '9c3b07a6d9b195a1192aea3cd78afd1f66c80710',
+)
+
+load('@org_pubref_rules_maven//maven:rules.bzl', 'maven_repositories')
+maven_repositories()
+
+load('@org_pubref_rules_maven//maven:rules.bzl', 'maven_repository')
+
+maven_repository(
+    name = 'tornadofx',
+    deps = [
+        'no.tornado:tornadofx:1.7.12',
+    ],
+    omit = [
+        '919f0dfe192fb4e063e7dacadee7f8bb9a2672a9:org.jetbrains:annotations:13.0',
+        '222365b4b684bfe35a7676c5ff69b4b414e398fa:org.jetbrains.kotlin:kotlin-reflect:1.1.51',
+        'e34fe80c9714240525f665113dd3749415515655:org.jetbrains.kotlin:kotlin-stdlib:1.1.51',
+        '8b5933578dc55f32cfc1a25f1db6371e4161fb8f:org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.51',
+        'cc8e639ff087472268912159cd66c01f2765c657:org.jetbrains.kotlin:kotlin-stdlib-jre8:1.1.51',
+    ],
+    transitive_deps = [
+        'b55f582add177fe166c9b375c6074eca7cee8642:no.tornado:tornadofx:1.7.12',
+        '3178f73569fd7a1e5ffc464e680f7a8cc784b85a:org.glassfish:javax.json:1.0.4',
+    ],
+)
+
+load('@tornadofx//:rules.bzl', 'tornadofx_compile')
+
+tornadofx_compile()
+


### PR DESCRIPTION
Also adds two new kotlin_compile attributes:

1. verbose: for printing debugging info
2. args: for passing arbitrary args to compilation

Adds new test from @jmmk re: tornadofx

Fixes #40 