### PR TITLE
Fixing kotlin_android_library

### DIFF
--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -255,6 +255,7 @@ def kotlin_android_library(
             name + "_aar",
         ],
         android_deps = res_deps,
+        kt_target_type = _target_type_library,
         **kwargs
     )
 


### PR DESCRIPTION
It was broken with an error like `missing value for mandatory attribute 'kt_target_type' in 'kotlin_compile' rule`