### PR TITLE
android: Update android_jar dependency

### DIFF
--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -242,7 +242,7 @@ def kotlin_android_library(
         name = name + "_sdk",
         neverlink = 1,
         jars = [
-            "//tools/defaults:android_jar",
+            "@bazel_tools//tools/android:android_jar",
         ],
     )
 


### PR DESCRIPTION
It's been moved on Bazel 0.13 release.